### PR TITLE
Healthcheck and auto remediation

### DIFF
--- a/alb.tf
+++ b/alb.tf
@@ -21,9 +21,10 @@ resource "aws_lb_target_group" "kf-alb-tg" {
   target_type = "instance"
 
   health_check {
-    path     = "/"
+    path     = "/healthcheck"
     protocol = "HTTP"
-    port     = 80
+    interval = 40
+    timeout  = 30
   }
 }
 

--- a/iam.tf
+++ b/iam.tf
@@ -18,6 +18,7 @@ resource "aws_iam_role" "kf-codebuild-role" {
 EOF
 }
 
+// TODO: alocate the statements by service and specify the resource to restrict the permissions
 resource "aws_iam_role_policy" "kf-codebuild-role-policy" {
   role = aws_iam_role.kf-codebuild-role.name
 
@@ -90,6 +91,7 @@ resource "aws_iam_role" "kf-cdppln-role" {
 EOF
 }
 
+// TODO: alocate the statements by service and specify the resource to restrict the permissions
 resource "aws_iam_role_policy" "kf-cdppln-role-policy" {
   name = "kf-cdppln-role-policy"
   role = aws_iam_role.kf-cdppln-role.id
@@ -199,4 +201,100 @@ data "aws_iam_policy_document" "codedeploy" {
 resource "aws_iam_role_policy" "codedeploy" {
   role   = aws_iam_role.codedeploy.name
   policy = data.aws_iam_policy_document.codedeploy.json
+}
+
+# AWS EC2 (TODO: the other IAM sections should follow this style of declaring)
+resource "aws_iam_role" "ec2-instance-role" {
+  name               = "${var.service_name}-ec2-instance-role"
+  path               = "/"
+  assume_role_policy = <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Principal": {
+        "Service": "ec2.amazonaws.com"
+      },
+      "Action": "sts:AssumeRole"
+    }
+  ]
+}
+EOF
+}
+
+resource "aws_iam_policy" "s3-perm-policy" {
+  name        = "s3-perm-policy"
+  description = "The ec2 instance need basic permission to cp artifact object (s3:PutObject) from the latest build in case of auto remediation."
+
+  policy = <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Action": [
+        "s3:GetObject",
+        "s3:GetObjectVersion",
+        "s3:GetBucketVersioning",
+        "s3:PutObject",
+        "s3:ListBucket",
+        "s3:ListObjectVersions"
+      ],
+      "Effect": "Allow",
+      "Resource": [
+        "${aws_s3_bucket.kf-cdppln-bucket.arn}",
+        "${aws_s3_bucket.kf-cdppln-bucket.arn}/*"
+      ]
+    }
+  ]
+}
+EOF
+}
+
+resource "aws_iam_policy" "get-pipeline-state" {
+  name        = "get-pipeline-state"
+  description = "In case of auto-remediation the script need to know the state of the pipeline."
+
+  policy = <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Action": [
+        "codepipeline:GetPipelineState"
+      ],
+      "Effect": "Allow",
+      "Resource": [
+        "${aws_codepipeline.kf-codepipeline.arn}"
+      ]
+    }
+  ]
+}
+EOF
+}
+
+resource "aws_iam_role_policy_attachment" "ec2-instance-role-attachment_main" {
+  role       = aws_iam_role.ec2-instance-role.name
+  policy_arn = "arn:aws:iam::aws:policy/service-role/AmazonEC2ContainerServiceforEC2Role"
+}
+
+# For the sake of debugging the container or some of the services
+resource "aws_iam_role_policy_attachment" "ec2-instance-role-attachment_allow_ssm_session" {
+  role       = aws_iam_role.ec2-instance-role.name
+  policy_arn = "arn:aws:iam::aws:policy/AmazonSSMManagedInstanceCore"
+}
+
+resource "aws_iam_role_policy_attachment" "ec2-instance-role-attachment_ecr_ro" {
+  role       = aws_iam_role.ec2-instance-role.name
+  policy_arn = "arn:aws:iam::aws:policy/AmazonEC2ContainerRegistryReadOnly"
+}
+
+resource "aws_iam_role_policy_attachment" "ec2-instance-role-attachment_s3" {
+  role       = aws_iam_role.ec2-instance-role.name
+  policy_arn = aws_iam_policy.s3-perm-policy.arn
+}
+
+resource "aws_iam_role_policy_attachment" "ec2-instance-role-attachment_codepipeline" {
+  role       = aws_iam_role.ec2-instance-role.name
+  policy_arn = aws_iam_policy.get-pipeline-state.arn
 }

--- a/launch_configuration.tf
+++ b/launch_configuration.tf
@@ -11,7 +11,7 @@ data "aws_ami" "amazon-linux" {
 }
 
 resource "aws_launch_configuration" "kf_lc" {
-  name                 = "EC2-Instance-${var.service_name}"
+  name_prefix          = "EC2-Instance-${var.service_name}"
   image_id             = data.aws_ami.amazon-linux.id
   instance_type        = var.ec2_instance_type
   iam_instance_profile = aws_iam_instance_profile.ec2-instance-profile.id
@@ -29,34 +29,8 @@ resource "aws_launch_configuration" "kf_lc" {
   security_groups = [
     aws_security_group.ec2.id
   ]
-  user_data = <<EOF
-  #!/bin/bash
-  # install the AWS CodeDeploy agent
-  sudo yum update -y
-  sudo yum install -y ruby
-  sudo yum install wget
-  cd /home/ec2-user
-  wget https://aws-codedeploy-${var.region}.s3.${var.region}.amazonaws.com/latest/install
-  chmod +x ./install
-  sudo ./install auto
 
-  # start the CodeDeploy agent
-  sudo service codedeploy-agent start
-
-  # Install the necessary packages
-  sudo yum update -y
-  sudo yum install -y docker
-
-  # Start the Docker service
-  sudo service docker start
-
-  # Add the ec2-user to the docker group
-  sudo usermod -a -G docker ec2-user
-
-  # Install jq
-  sudo yum update -y
-  sudo yum install jq -y
-  EOF
+  user_data = data.template_cloudinit_config.kf_lc-user-data.rendered
 }
 
 resource "aws_autoscaling_group" "kf_asg" {
@@ -78,73 +52,8 @@ resource "aws_autoscaling_group" "kf_asg" {
   }
 }
 
-resource "aws_iam_role" "ec2-instance-role" {
-  name               = "${var.service_name}-ec2-instance-role"
-  path               = "/"
-  assume_role_policy = <<EOF
-{
-  "Version": "2012-10-17",
-  "Statement": [
-    {
-      "Effect": "Allow",
-      "Principal": {
-        "Service": "ec2.amazonaws.com"
-      },
-      "Action": "sts:AssumeRole"
-    }
-  ]
-}
-EOF
-}
-
-resource "aws_iam_policy" "s3-perm-policy" {
-  name        = "s3-perm-policy"
-  description = "A test policy"
-
-  policy = <<EOF
-{
-  "Version": "2012-10-17",
-  "Statement": [
-    {
-      "Action": [
-        "s3:GetObject",
-        "s3:GetObjectVersion",
-        "s3:GetBucketVersioning"
-      ],
-      "Effect": "Allow",
-      "Resource": [
-        "${aws_s3_bucket.kf-cdppln-bucket.arn}",
-        "${aws_s3_bucket.kf-cdppln-bucket.arn}/*"
-      ]
-    }
-  ]
-}
-EOF
-}
-
 resource "aws_iam_instance_profile" "ec2-instance-profile" {
   name = "${var.service_name}-ec2-instance-profile"
   path = "/"
   role = aws_iam_role.ec2-instance-role.id
-}
-
-resource "aws_iam_role_policy_attachment" "ec2-instance-role-attachment_main" {
-  role       = aws_iam_role.ec2-instance-role.name
-  policy_arn = "arn:aws:iam::aws:policy/service-role/AmazonEC2ContainerServiceforEC2Role"
-}
-
-# For the sake of debugging the container or some of the services
-resource "aws_iam_role_policy_attachment" "ec2-instance-role-attachment_allow_ssm_session" {
-  role       = aws_iam_role.ec2-instance-role.name
-  policy_arn = "arn:aws:iam::aws:policy/AmazonSSMManagedInstanceCore"
-}
-
-resource "aws_iam_role_policy_attachment" "ec2-instance-role-attachment_ecr_ro" {
-  role       = aws_iam_role.ec2-instance-role.name
-  policy_arn = "arn:aws:iam::aws:policy/AmazonEC2ContainerRegistryReadOnly"
-}
-
-resource "aws_iam_role_policy_attachment" "ec2-instance-role-attachment_s3" {
-  role       = aws_iam_role.ec2-instance-role.name
-  policy_arn = aws_iam_policy.s3-perm-policy.arn
 }

--- a/launch_configuration_template.tf
+++ b/launch_configuration_template.tf
@@ -1,0 +1,32 @@
+data "template_file" "kf_lc-codedeploy-agent" {
+  template = file("scripts/provision_codedeploy_agent.sh")
+  vars = {
+    region = var.region
+  }
+}
+
+data "template_file" "kf_lc-auto-remediate" {
+  template = file("scripts/auto_remediate.sh")
+  vars = {
+    artifacts_bucket = aws_s3_bucket.kf-cdppln-bucket.bucket
+    service_name     = var.service_name
+    region           = var.region
+  }
+}
+
+data "template_cloudinit_config" "kf_lc-user-data" {
+  gzip          = true
+  base64_encode = true
+
+  part {
+    filename     = "provision_codedeploy_agent.sh"
+    content_type = "text/x-shellscript"
+    content      = data.template_file.kf_lc-codedeploy-agent.rendered
+  }
+
+  part {
+    filename     = "auto_remediate.sh"
+    content_type = "text/x-shellscript"
+    content      = data.template_file.kf_lc-auto-remediate.rendered
+  }
+}

--- a/scripts/auto_remediate.sh
+++ b/scripts/auto_remediate.sh
@@ -1,0 +1,94 @@
+#!/bin/bash
+
+if [ ! -x "$(command -v docker)" ] && [ ! -x "$(command --version jq)" ]; then
+    echo "Install docker & jq"
+    
+    # Install the necessary packages
+    yum update -y
+    yum install -y docker
+
+    # Start the Docker service
+    service docker start
+
+    # Add the ec2-user to the docker group
+    usermod -a -G docker ec2-user
+
+    # Install jq
+    yum update -y
+    yum install jq -y
+fi
+
+# create a folder where to store the logs (TODO: move to the /var/log instead)
+mkdir -p auto_remediate_log
+
+LOG_LOCATION=auto_remediate_log/ec2-app-remediate.log
+
+touch $LOG_LOCATION
+
+# Initialize some logger
+function logger () {
+    exec > >(tee -i $LOG_LOCATION)
+    exec 2>&1
+    now=$(date +'%m/%d/%Y %H:%M')
+    echo "$1: [$now] $2"
+}
+
+# 0. Determine while docker container named TechChallenge is running (TODO: the container name as var)
+if [ "$(docker ps --format '{{.Names}}')" == "TechChallengeApp" ]; then
+    logger "INFO" "The container is still running. No action required."
+    exit 0;
+fi
+
+# 1. Determine while EC2 is running along with a pipeline and it waits for deployment
+CHECK_PIPELINE_RUNNING=$(aws codepipeline get-pipeline-state --name karakonjul-codepipeline --region ${region} | jq -r '.stageStates[].latestExecution.status' |grep InProgress)
+
+if [ ! -z "$CHECK_PIPELINE_RUNNING" ]; then
+    logger "INFO" "CodePipeline is still In Progress. Seems this is a regular deployment and the container will start in a moments..."
+    exit 0;
+fi
+
+# 2. If the script reached this point - means the container isn't running and there isn't deployment in progress
+# Go for the latest build
+KEY=$(aws s3 ls ${artifacts_bucket}/${service_name}-codepipel/build/ | sort | tail -n 1 | awk '{print $4}')
+
+if [ -z "$KEY" ]; then
+    logger "ERROR" "The requested KEY does not exist in S3 bucket ${artifacts_bucket}. It's a strange situation."
+    exit 1;
+fi
+
+DOWNLOAD_LATEST_BUILD_ARTIFACTS=$(aws s3 cp s3://${artifacts_bucket}/${service_name}-codepipel/build/$KEY ./latest-build-artifact)
+
+if [ -z "$DOWNLOAD_LATEST_BUILD_ARTIFACTS" ]; then
+    logger "ERROR" "The artifacts weren't downloaded. Check the S3 permissions or either the bucket [${artifacts_bucket}] or key [$KEY] exist."
+
+    exit 1;
+fi
+
+# 3. Unzip the artifacts
+unzip -o latest-build-artifact
+
+# 4. Check scripts folder is now available
+CHECK_SCRIPTS_EXISTS=$(ls -la scripts)
+
+if [ -z "$CHECK_SCRIPTS_EXISTS" ]; then
+    logger "ERROR" "The scripts folder isn't existing."
+
+    exit 1;
+fi
+
+# 5. Run the squence of the scripts: login to ecr
+logger "INFO" "Running login_to_ecr script."
+chmod +x /scripts/login_to_ecr.sh ; source /scripts/login_to_ecr.sh
+
+# 6. Run the squence of the scripts: start the server
+logger "INFO" "Running start_server script."
+chmod +x /scripts/start_server.sh ; source /scripts/start_server.sh
+
+# 7. Check if there is running process in docker
+IS_DOCKER_RUNNING=$(docker ps) 
+
+if [ -z "$IS_DOCKER_RUNNING" ]; then
+    logger "CRITICAL" "You have bigger problem than app not just running. Better check your DB."
+
+    exit 1;
+fi

--- a/scripts/provision_codedeploy_agent.sh
+++ b/scripts/provision_codedeploy_agent.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+
+# install the AWS CodeDeploy agent
+yum update -y
+yum install -y ruby
+yum install wget
+cd /home/ec2-user
+wget https://aws-codedeploy-${region}.s3.${region}.amazonaws.com/latest/install
+chmod +x ./install
+./install auto
+
+# start the CodeDeploy agent
+service codedeploy-agent start
+
+# Install the necessary packages
+yum update -y
+yum install -y docker
+
+# Start the Docker service
+service docker start
+
+# Add the ec2-user to the docker group
+usermod -a -G docker ec2-user
+
+# Install jq
+yum update -y
+yum install jq -y


### PR DESCRIPTION
This PR consists from 3 commits:
- Add the exact app `healtchcheck` endpoint for target group health checking
- Add all IAM resources in one place (iam.tf)
- Create auto remediation script:
I observed very worrisome behaviour when some of the healthchecks got fallen. Then
the new arrived ec2 instances weren't able to run the app: into the fresh instances the start scripts and all needed requisites to run the app, which are usually coming as a codedeploy artifacts, are missing.
Thats why I created script to lookup for these artifacts (last stable build) and to bring them on the instance and then to run the service.